### PR TITLE
#16: Add missing npm prepare script.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.4.5
+* [#16: Add missing `npm prepare` script.](https://github.com/haensl/eslint-config/issues/16)
+
 ## 1.4.4
 * [#14: Add funding information.](https://github.com/haensl/eslint-config/issues/14)
 * Update dependencies.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haensl/eslint-config",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "Default ESLint configuration of HP Dietz.",
   "main": "lib/index.js",
   "publishConfig": {
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "lint": "eslint './**/*.js'",
-    "lint:ci": "eslint --format junit -o test-results/eslint/results.xml './**/*.js'"
+    "lint:ci": "eslint --format junit -o test-results/eslint/results.xml './**/*.js'",
+    "prepare": "if [ $NODE_ENV != 'production' ]; then husky install; fi"
   },
   "eslintConfig": {
     "env": {


### PR DESCRIPTION
## 1.4.5
* [#16: Add missing `npm prepare` script.](https://github.com/haensl/eslint-config/issues/16)

Closes #16 